### PR TITLE
Hack for doc_dir

### DIFF
--- a/flask_openapi/__init__.py
+++ b/flask_openapi/__init__.py
@@ -1,5 +1,5 @@
 
-__version__ = '1.0.0a'
+__version__ = '1.1.0'
 __author__ = 'Overflow Digital'
 __email__ = 'team@overflow.digital'
 

--- a/flask_openapi/base.py
+++ b/flask_openapi/base.py
@@ -7,7 +7,6 @@ we add the endpoint to swagger specification output
 
 """
 import codecs
-import logging
 import os
 import re
 from typing import Optional


### PR DESCRIPTION
Part of https://github.com/overflowdigital/Flask-OpenAPI/issues/13
Sometimes the doc_dir doesn't match up with the filepath so squash the end of the filepath and the doc_dir together to get the correct filepath. Also fix the imports.