### PR TITLE
Fix verb duplicates

### DIFF
--- a/flask_openapi/__init__.py
+++ b/flask_openapi/__init__.py
@@ -1,5 +1,5 @@
 
-__version__ = '1.3.1'
+__version__ = '1.3.2'
 __author__ = 'Overflow Digital'
 __email__ = 'team@overflow.digital'
 

--- a/flask_openapi/base.py
+++ b/flask_openapi/base.py
@@ -456,6 +456,7 @@ class Swagger(object):
                 dest[key].update(source)
 
         def get_operations(swag, path_verb = None):
+
             if is_openapi3(openapi_version):
                 source_components = swag.get('components', {})
                 update_schemas = source_components.get('schemas', {})
@@ -577,7 +578,8 @@ class Swagger(object):
                     try:
                         for path in swag.get('paths'): # /projects/{project_id}/alarms:
                             for path_verb in swag.get('paths').get(path): # get:
-                                get_operations(swag.get('paths').get(path).get(path_verb), path_verb)
+                                if path_verb == verb:
+                                    get_operations(swag.get('paths').get(path).get(path_verb), path_verb)
                     except AttributeError:
                         logging.exception(f'Swagger doc not in the correct format. {swag}')
                 else:


### PR DESCRIPTION
Had an issue where we were getting duplicates if there were different paths in the same file. This adds a check so we only pass build out the method if the swagger doc verb matches the class verb.

Before:
![image](https://user-images.githubusercontent.com/36820402/207054519-43b135b3-a53e-4f93-b672-e4570457b80e.png)

After:
![image](https://user-images.githubusercontent.com/36820402/207054595-abbc9924-4dad-4e73-b172-0ab76af90b94.png)
