### PR TITLE
Improve the CI/CD and Build Pipelines

### DIFF
--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -16,10 +16,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Initialize Runtime Code Analysis
-        uses: github/codeql-action/init@v2
-        with:
-          languages: python
       - name: Setup Worker
         run: ci/scripts/setup_worker.sh
       - name: Increment Version Number
@@ -28,14 +24,6 @@ jobs:
         run: ci/scripts/build.sh
       - name: Perform Static Code Analysis
         run: ci/scripts/codescan.sh
-      - name: Perform Runtime Code Analysis
-        uses: github/codeql-action/analyze@v2
-      - name: Perform Secure Code Analysis (Secrets)
-        uses: trufflesecurity/trufflehog@main
-        with:
-          path: ./
-          base: ${{ github.ref_name }}
-          head: HEAD
       - name: Run Unit Tests
         run: ci/scripts/test_runner.sh
       - name: Upload release to PyPI

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,7 +1,7 @@
 name: Continuous Deployment
 on:
   schedule:
-    - cron: "00 09 * * 1"
+    - cron: "00 09 1 * *"
 jobs:
   pre_release_check:
     name: Pre-release Check
@@ -30,26 +30,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Initialize Runtime Code Analysis
-        uses: github/codeql-action/init@v2
-        with:
-          languages: python
       - name: Setup Worker
         run: ci/scripts/setup_worker.sh
       - name: Increment Version Number
-        run: ci/scripts/new_version.sh --auto_increment
+        run: ci/scripts/new_version.sh auto_increment
       - name: Build Package and Verify
         run: ci/scripts/build.sh
       - name: Perform Static Code Analysis
         run: ci/scripts/codescan.sh
-      - name: Perform Runtime Code Analysis
-        uses: github/codeql-action/analyze@v2
-      - name: Perform Secure Code Analysis (Secrets)
-        uses: trufflesecurity/trufflehog@main
-        with:
-          path: ./
-          base: ${{ github.ref_name }}
-          head: HEAD
       - name: Run Unit Tests
         run: ci/scripts/test_runner.sh
       - name: Upload release to PyPI

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,36 +1,25 @@
 name: Continuous Integration
 on:
+  pull_request:
+    branches:
+    - master
   push:
+    branches:
+    - master
   schedule:
     - cron: "00 09 * * *"
 jobs:
   continuous_integration:
     name: Continuous Integration
-    permissions:
-      actions: read
-      contents: read
-      security-events: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Initialize Runtime Code Analysis
-        uses: github/codeql-action/init@v2
-        with:
-          languages: python
       - name: Setup Worker
         run: ci/scripts/setup_worker.sh
       - name: Build Package and Verify
         run: ci/scripts/build.sh
       - name: Perform Static Code Analysis
         run: ci/scripts/codescan.sh
-      - name: Perform Runtime Code Analysis
-        uses: github/codeql-action/analyze@v2
-      - name: Perform Secure Code Analysis (Secrets)
-        uses: trufflesecurity/trufflehog@main
-        with:
-          path: ./
-          base: ${{ github.ref_name }}
-          head: HEAD
       - name: Run Unit Tests
         run: ci/scripts/test_runner.sh
       - name: Upload Test Report

--- a/ci/scripts/build.sh
+++ b/ci/scripts/build.sh
@@ -8,5 +8,5 @@ REPO=$(dirname "$REPO../")
 REPO=$(dirname "$REPO../")
 
 cd $REPO
-sudo python3 -m build
-sudo python3 -m twine check $REPO/dist/*
+python3 -m build
+python3 -m twine check $REPO/dist/*

--- a/ci/scripts/setup_worker.sh
+++ b/ci/scripts/setup_worker.sh
@@ -10,6 +10,3 @@ REPO=$(dirname "$REPO../")
 python3 -m pip install --upgrade pip
 python3 -m pip install -r $REPO/ci/config/requirements.txt
 python3 -m pip install -r $REPO/requirements.txt
-sudo python3 -m pip install --upgrade pip
-sudo python3 -m pip install -r $REPO/ci/config/requirements.txt
-sudo python3 -m pip install -r $REPO/requirements.txt


### PR DESCRIPTION
* Makes the CI pipeline faster, we no longer do runtime analysis, we don't really need it.
* Makes the CD pipeline run on the 1st of the month
* CI only runs on PRs and pushes to master